### PR TITLE
added vcf parsing for freebayes and sanity check for gff parsing

### DIFF
--- a/virheat/__init__.py
+++ b/virheat/__init__.py
@@ -1,3 +1,3 @@
 """plot vcf data as a heatmap mapped to a virus genome"""
 _program = "virheat"
-__version__ = "0.7.1"
+__version__ = "0.7.2"

--- a/virheat/command.py
+++ b/virheat/command.py
@@ -26,7 +26,7 @@ def get_args(sysargs):
     """
     parser = argparse.ArgumentParser(
         prog=_program,
-        usage='''\tvirheat <folder containing input files (vcf/tsv)> <output dir> -l or -g [additional arguments]''')
+        usage='''\tvirheat <folder containing input files (vcf/tsv)> <output dir> -r -l/-g [additional arguments]''')
     parser.add_argument(
         "input",
         nargs=2,

--- a/virheat/scripts/data_prep.py
+++ b/virheat/scripts/data_prep.py
@@ -294,7 +294,13 @@ def parse_gff3(file, reference):
             # ignore comments and last line
             if not line.startswith(reference):
                 continue
-            gff_values = line.split("\t")
+            gff_values = line.strip().split("\t")
+            # sanity check that the line has a unique ID for the dict key
+            # this is a lazy fix as it will exclude e.g. exons without ID and
+            # only a parent -> fixing this might require more complex parsing
+            # and data structure
+            if not gff_values[8].startswith("ID="):
+                continue
             # create keys
             if gff_values[2] not in gff3_dict:
                 gff3_dict[gff_values[2]] = {}

--- a/virheat/scripts/data_prep.py
+++ b/virheat/scripts/data_prep.py
@@ -297,8 +297,7 @@ def parse_gff3(file, reference):
             gff_values = line.strip().split("\t")
             # sanity check that the line has a unique ID for the dict key
             # this is a lazy fix as it will exclude e.g. exons without ID and
-            # only a parent -> fixing this might require more complex parsing
-            # and data structure
+            # only a parent
             if not gff_values[8].startswith("ID="):
                 continue
             # create keys

--- a/virheat/scripts/data_prep.py
+++ b/virheat/scripts/data_prep.py
@@ -108,10 +108,10 @@ def read_vcf(vcf_file, reference):
                 val_list = val.split(',')
                 for value in val_list:
                     vcf_dict[key].append(convert_string(value))
-                    visited_keys.append(key)
-        # append none for ech none visited key
+                visited_keys.append(key)
+        # append none for each none visited key in the INFO field
         for key in [k for k in vcf_dict.keys() if k not in visited_keys]:
-            vcf_dict[key].append(None)
+            vcf_dict[key].extend([None]*length_variants)
 
     return vcf_dict
 

--- a/virheat/scripts/data_prep.py
+++ b/virheat/scripts/data_prep.py
@@ -309,10 +309,10 @@ def parse_gff3(file, reference):
                 # create a new dict for each ID
                 if identifier == "ID" and identifier not in gff3_dict:
                     attribute_id = val
-                    gff3_dict[gff_values[2]][attribute_id] = {}
+                    gff3_dict[gff_values[2]][val] = {}
                 # add attributes
                 if identifier != "ID":
-                    gff3_dict[gff_values[2]][attribute_id][identifier] = val.replace("\n", "")
+                    gff3_dict[gff_values[2]][attribute_id][identifier] = val
             # add start, stop and strand
             gff3_dict[gff_values[2]][attribute_id]["start"] = int(gff_values[3])
             gff3_dict[gff_values[2]][attribute_id]["stop"] = int(gff_values[4])


### PR DESCRIPTION
Currently virheat did not support if there were multiple variants associated to one position (e.g. FreeBayes caller). This now allows parsing of these vcf files. 
