### PR TITLE
Enable arrows in the gene vis

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ options:
                         path to gff3 (needed if length is not provided)
   -a [gene ...], --gff3-annotations [gene ...]
                         annotations to display from gff3 file (standard: gene). Multiple possible.
+  --gene-arrows, --no-gene-arrows
+                        show genes in arrow format (only if the -g argument is provided) (default: False)
   -t 0, --threshold 0   display frequencies above this threshold (0-1)
   --delete, --no-delete
                         delete mutations that are present in all samples and their maximum frequency divergence is smaller than 0.5 (default: True)

--- a/virheat/__init__.py
+++ b/virheat/__init__.py
@@ -1,3 +1,3 @@
 """plot vcf data as a heatmap mapped to a virus genome"""
 _program = "virheat"
-__version__ = "0.7.2"
+__version__ = "0.7.3"

--- a/virheat/command.py
+++ b/virheat/command.py
@@ -75,6 +75,12 @@ def get_args(sysargs):
         help="annotations to display from gff3 file (standard: gene). Multiple possible."
     )
     parser.add_argument(
+        "--gene-arrows",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="show genes as arrows"
+    )
+    parser.add_argument(
         "-t",
         "--threshold",
         type=float,
@@ -243,7 +249,7 @@ def main(sysargs=sys.argv[1:]):
             cmap_genes = plt.get_cmap('tab20', len(genes_with_mutations))
             colors_genes = [cmap_genes(i) for i in range(len(genes_with_mutations))]
             # plot gene track
-            plotting.create_gene_vis(ax, genes_with_mutations, n_mutations, y_size, n_tracks, start, stop, min_y_location, genome_y_location, colors_genes, n_scores)
+            plotting.create_gene_vis(ax, genes_with_mutations, n_mutations, y_size, n_tracks, start, stop, min_y_location, genome_y_location, colors_genes, n_scores, show_arrows=args.gene_arrows)
     # plot scores as track below the gene/genome track
     if args.scores:
         score_count = 1

--- a/virheat/scripts/data_prep.py
+++ b/virheat/scripts/data_prep.py
@@ -316,6 +316,7 @@ def parse_gff3(file, reference):
             # add start, stop and strand
             gff3_dict[gff_values[2]][attribute_id]["start"] = int(gff_values[3])
             gff3_dict[gff_values[2]][attribute_id]["stop"] = int(gff_values[4])
+            gff3_dict[gff_values[2]][attribute_id]["strand"] = gff_values[6]
 
     gff3_file.close()
 
@@ -350,7 +351,6 @@ def create_track_dict(unique_mutations, gff3_info, annotation_type):
 
     # find genes that have a mutation
     genes_with_mutations = set()
-
     for mutation in unique_mutations:
         # get the mutation from string
         mutation = int(mutation.split("_")[0])
@@ -366,7 +366,8 @@ def create_track_dict(unique_mutations, gff3_info, annotation_type):
                     genes_with_mutations.add(
                         (attribute_name,
                          gff3_info[type][annotation]["start"],
-                         gff3_info[type][annotation]["stop"])
+                         gff3_info[type][annotation]["stop"],
+                         gff3_info[type][annotation]["strand"])
                     )
     if not genes_with_mutations:
         print("\033[31m\033[1mWARNING:\033[0m either the annotation types were not found in gff3 or the mutations are not within genes.")

--- a/virheat/scripts/plotting.py
+++ b/virheat/scripts/plotting.py
@@ -218,7 +218,7 @@ def create_gene_vis(ax, genes_with_mutations, n_mutations, y_size, n_tracks, sta
     gene_annotations = []
     mult_factor = n_mutations/(stop-start)
     # define arrow head length for all arrows
-    # dependend on how long the relative genes are to each other. If they are similar in length, it is roughly one 8th
+    # dependent on how long the relative genes are to each other. If they are similar in length, it is roughly 1/8
     # of the shortest gene to display.
     if show_arrows:
         all_gene_lengths = [genes_with_mutations[x][0][1]-genes_with_mutations[x][0][0] for x in genes_with_mutations.keys()]

--- a/virheat/scripts/plotting.py
+++ b/virheat/scripts/plotting.py
@@ -218,17 +218,16 @@ def create_gene_vis(ax, genes_with_mutations, n_mutations, y_size, n_tracks, sta
     gene_annotations = []
     mult_factor = n_mutations/(stop-start)
     # define arrow head length for all arrows
-    # dependent on how long the relative genes are to each other. If they are similar in length, it is roughly 1/8
+    # dependent on how long the relative genes are to each other. If they are similar in length, it is 15%
     # of the shortest gene to display.
     if show_arrows:
-        all_gene_lengths = [genes_with_mutations[x][0][1]-genes_with_mutations[x][0][0] for x in genes_with_mutations.keys()]
-        if min(all_gene_lengths)*20 < max(all_gene_lengths):
-            head_length = mult_factor*min(all_gene_lengths)
-        elif min(all_gene_lengths)*10 < max(all_gene_lengths):
-            head_length = mult_factor * min(all_gene_lengths) * 0.6
-        elif min(all_gene_lengths)*5 < max(all_gene_lengths):
-            head_length = mult_factor * min(all_gene_lengths) * 0.3
-        else:
+        all_gene_lengths, mult_detected = [genes_with_mutations[x][0][1]-genes_with_mutations[x][0][0] for x in genes_with_mutations.keys()], False
+
+        for min_len_mult, head_len_mult in zip([20, 10, 5], [1, 0.6, 0.3]):
+            if min(all_gene_lengths)*min_len_mult < max(all_gene_lengths):
+                head_length, mult_detected = mult_factor * min(all_gene_lengths) * head_len_mult, True
+                break
+        if not mult_detected:
             head_length = mult_factor * min(all_gene_lengths) * 0.15
 
     for idx, gene in enumerate(genes_with_mutations):

--- a/virheat/scripts/plotting.py
+++ b/virheat/scripts/plotting.py
@@ -210,7 +210,7 @@ def create_axis(ax, n_mutations, min_y_location, n_samples, file_names, start, s
     ax.spines["left"].set_visible(False)
 
 
-def create_gene_vis(ax, genes_with_mutations, n_mutations, y_size, n_tracks, start, stop, min_y_location, genome_y_location, colors_genes, n_scores, show_arrows = True):
+def create_gene_vis(ax, genes_with_mutations, n_mutations, y_size, n_tracks, start, stop, min_y_location, genome_y_location, colors_genes, n_scores, show_arrows):
     """
     create the vis for the gene
     """


### PR DESCRIPTION
Now genes can be displayed with direction dependent arrows with `--gene-arrows ` (default:False)